### PR TITLE
fix: make Link underline by default for clarity

### DIFF
--- a/src/inline-text/link/link.module.css
+++ b/src/inline-text/link/link.module.css
@@ -1,11 +1,8 @@
 .link {
   color: var(--figma-color-text-brand);
   pointer-events: all;
-  text-decoration: none;
 }
-.link:hover {
-  text-decoration: underline;
-}
+
 .link:focus {
   background-color: var(--figma-color-bg-selected);
   border-radius: var(--border-radius-2);


### PR DESCRIPTION
Now that we made the link a bit darker on our banner component to have enough contrast on yellow background, I found that it's harder to notice that the word is an anchor link 
![image](https://user-images.githubusercontent.com/36734656/192274446-3f6704cb-7f4b-4be7-88d6-ccca1a9d89d8.png)


I discussed with @thais-divriots and it's probably just better to underline link by default, not just on hover, so that it's clear to users that there is a link. This is a recommendation anyway in WCAG: 

Best practice is to underline all links in content. 
However, if your links are not underlined, web accessibility guidelines ([WCAG 2.0](https://webaim.org/standards/wcag/)) require link text be discernable from body text by at least a 3:1 contrast ratio.

and since 3:1 contrast ratio with text is going to be very hard/ugly while also text and link both having enough contrast on the yellow background, the underline is the best option